### PR TITLE
Add summary section

### DIFF
--- a/lib/solidus_page_objects.rb
+++ b/lib/solidus_page_objects.rb
@@ -22,6 +22,7 @@ require 'solidus_page_objects/components/sidebar'
 require 'solidus_page_objects/components/cart_item'
 require 'solidus_page_objects/components/cart'
 require 'solidus_page_objects/components/checkout/address'
+require 'solidus_page_objects/components/checkout/summary'
 
 # require sections
 require 'solidus_page_objects/sections/main_navigation'
@@ -41,6 +42,7 @@ require 'solidus_page_objects/sections/cart_item'
 require 'solidus_page_objects/sections/cart'
 require 'solidus_page_objects/sections/checkout/address'
 require 'solidus_page_objects/sections/checkout/customer_information'
+require 'solidus_page_objects/sections/checkout/summary'
 
 # require pages
 require 'solidus_page_objects/pages/checkout/address'

--- a/lib/solidus_page_objects/components/checkout.rb
+++ b/lib/solidus_page_objects/components/checkout.rb
@@ -1,6 +1,9 @@
 module SolidusPageObjects
   module Components
     module Checkout
+      def self.included(base)
+        base.section :summary, SolidusPageObjects::Sections::Checkout::Summary, '#checkout-summary'
+      end
     end
   end
 end

--- a/lib/solidus_page_objects/components/checkout/summary.rb
+++ b/lib/solidus_page_objects/components/checkout/summary.rb
@@ -1,0 +1,16 @@
+module SolidusPageObjects
+  module Components
+    module Checkout
+      module Summary
+        def self.included(base)
+          base.element :table, 'table'
+        end
+
+        def value_of(header)
+          tr = table.find('tbody tr', text: header)
+          tr.find_all('td')[1].text if tr.present?
+        end
+      end
+    end
+  end
+end

--- a/lib/solidus_page_objects/sections/checkout/summary.rb
+++ b/lib/solidus_page_objects/sections/checkout/summary.rb
@@ -1,0 +1,9 @@
+module SolidusPageObjects
+  module Sections
+    module Checkout
+      class Summary < SitePrism::Section
+        include Components::Checkout::Summary
+      end
+    end
+  end
+end

--- a/spec/solidus_page_objects/sections/checkout/summary_spec.rb
+++ b/spec/solidus_page_objects/sections/checkout/summary_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+RSpec.describe SolidusPageObjects::Sections::Checkout::Summary do
+  let(:order) { OrderWalkthrough.up_to(:address) }
+  let(:user) { create(:user) }
+
+  before do
+    order.update_attribute(:user, user)
+    allow_any_instance_of(Spree::CheckoutController).to receive_messages current_order: order,
+                                                                         spree_current_user: user
+  end
+
+  let!(:page) { SolidusPageObjects::Pages::Checkout::Address.new.tap(&:load) }
+
+  subject { page.summary }
+
+  describe '#value_of' do
+    it 'return the value_of specific row' do
+      expect(subject.value_of('Item Total')).to eq order.display_item_total.to_html
+    end
+  end
+end


### PR DESCRIPTION
The checkout process has a table with summary information (item total,
order total etc...), this section add the ability to take the information
from summary row.